### PR TITLE
Fixed pip install instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use python 3.
 
 ### Main installs:
 ```
-pip3 install requirements.txt
+pip3 install -r requirements.txt
 ```
 
 ### Install gym


### PR DESCRIPTION
`pip` needs the `-r` option to install from a requirement.txt file.