### PR TITLE
Fix MountainCar expert policy

### DIFF
--- a/mountain_car_expert.py
+++ b/mountain_car_expert.py
@@ -26,7 +26,7 @@ def perform_expert_episodes_bangbang(simu, batch, nb_trajs, render=False):
             state, reward, done = simu.take_step(state, action, episode, render)
 
         for t in count():
-            action = [1]
+            action = [2]
             state, reward, done = simu.take_step(state, action, episode, render)
 
             if done:


### PR DESCRIPTION
The bangbang policy is described as left -> right, but the action 1 is "no acceleration" in the discrete case.