### PR TITLE
Fix regress loss

### DIFF
--- a/policies/bernoulli_policy.py
+++ b/policies/bernoulli_policy.py
@@ -88,6 +88,6 @@ class BernoulliPolicy(GenericNet):
           """
         action = torch.FloatTensor(action)
         proposed_action = self.forward(state)
-        loss = func.mse_loss(proposed_action, action)
+        loss = func.binary_cross_entropy(proposed_action, action)
         self.update(loss)
         return loss

--- a/policies/discrete_policy.py
+++ b/policies/discrete_policy.py
@@ -101,6 +101,6 @@ class DiscretePolicy(GenericNet):
         """
         action = torch.FloatTensor(action)
         proposed_action = self.forward(state)
-        loss = func.mse_loss(proposed_action, action)
+        loss = func.cross_entropy(proposed_action, action.flatten().long())
         self.update(loss)
         return loss


### PR DESCRIPTION
The cross entropy loss is better suited to probabilities for the Bernoulli and Discrete policies. This also fixes shape issues for the discrete policy.