### PR TITLE
Set env seed in evaluator for fair comparison

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -57,12 +57,14 @@ class Evaluator:
                 env = make_env(pw.env_name, pw.policy_type, pw.max_steps)
                 env.set_reward_flag(False)
                 env.set_duration_flag(False)
+                env.seed(42)
                 scores = evaluate_pol(env, policy, False)
                 self.score_dict[pw.env_name][scores.mean()] = [pw.team_name, scores.std()]
             else:
                 env = make_env(pw.env_name, pw.policy_type, pw.max_steps)
                 env.set_reward_flag(False)
                 env.set_duration_flag(False)
+                env.seed(42)
                 self.env_dict[pw.env_name] = env
                 scores = evaluate_pol(env, policy, False)
                 tmp_score_dict = {scores.mean(): [pw.team_name, scores.std()]}


### PR DESCRIPTION
Set the seed of the gym env at its creation, before evaluating each policy. This does not mean that each env.reset() leads to the same state, but that the sequence of states from the resets is the same for all evaluated policies.

This is important for fair comparisons of scores of policies, especially for environments with high variance like pendulum.